### PR TITLE
Fix issue with play again functionality, already playing functionality + UI tweak

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -267,6 +267,7 @@ io.on('connection', function (socket) {
         }
 
         socket.wantsAgain = true
+        socket.game.initTable()
 
         socket.broadcast.to(socket.game.room)
             .emit('opponent-wants-again')

--- a/app/server.js
+++ b/app/server.js
@@ -169,7 +169,7 @@ io.on('connection', function (socket) {
         }
 
         // Opponent is already in a game
-        if (opponent.gameRoom) {
+        if (opponent.game) {
             socket.emit('match-failed', 'User is currently playing.')
             return
         }
@@ -265,7 +265,7 @@ io.on('connection', function (socket) {
 
         socket.wantsAgain = true
 
-        socket.broadcast.to(socket.gameRoom)
+        socket.broadcast.to(socket.game.room)
             .emit('opponent-wants-again')
     })
 

--- a/app/server.js
+++ b/app/server.js
@@ -72,6 +72,9 @@ function startGame(socket, opponent) {
         // tell both parties about the game
         socket.emit('game', { opponent: { id: opponent.id.replace('/#', ''), username: opponent.username }, game: opponent.game.room, starts: true })
         opponent.emit('game', { opponent: { id: socket.id.replace('/#', ''), username: socket.username }, game: opponent.game.room, starts: false })
+
+        socket.started = true
+        opponent.started = false
     })
 
     game.on('turn-switched', function (client) {

--- a/resources/assets/js/components/Welcome.vue
+++ b/resources/assets/js/components/Welcome.vue
@@ -9,6 +9,7 @@
                 <p :class="['control', {'has-icon has-icon-right': failResponse}]">
                     <input type="text"
                         :class="['input', {'is-danger': failResponse}]"
+                        autofocus
                         v-model="username"
                         placeholder="Choose your username...">
 


### PR DESCRIPTION
server.js was still referencing `socket.gameRoom` which no longer exists after the game refactoring by @hkan. This was causing the play again functionality not to work and also the functionality which informs users if an invited user is currently in a game.

Also added "autofocus" property to the "Enter your username" text field - was bugging me having to click/tab into it when testing!
